### PR TITLE
rfcx-local-cd: push build to in-cluster registry (64.21), not host-gw alias

### DIFF
--- a/.github/workflows/rfcx-local-cd.yaml
+++ b/.github/workflows/rfcx-local-cd.yaml
@@ -75,7 +75,14 @@ jobs:
         target: ${{ fromJson(inputs.targets) }}
       fail-fast: false
     env:
-      REGISTRY: 192.168.5.1:30500
+      # Push to the in-cluster registry by its DIRECT node address (control-plane
+      # NodePort), NOT the 192.168.5.1:30500 host-gateway alias. buildx/dockerd does
+      # NOT honor the k3s containerd registry mirror (192.168.5.1:30500 ->
+      # 192.168.64.21:30500), so on the build node 192.168.5.1:30500 hits a SEPARATE
+      # orphan host-gateway registry. The kubelet, which DOES follow the mirror, then
+      # pulls from 192.168.64.21:30500 and 404s (ImagePullBackOff). Pushing here makes
+      # build-push and kubelet-pull land on the same physical registry.
+      REGISTRY: 192.168.64.21:30500
     outputs:
       unique-tag: ${{ steps.meta.outputs.unique-tag }}
     steps:
@@ -86,7 +93,7 @@ jobs:
         with:
           driver: docker-container
           buildkitd-config-inline: |
-            [registry."192.168.5.1:30500"]
+            [registry."192.168.64.21:30500"]
               http = true
               insecure = true
 
@@ -121,6 +128,10 @@ jobs:
         entry: ${{ fromJson(inputs.deployments) }}
       fail-fast: false
     env:
+      # set image references the 192.168.5.1:30500 host-gateway alias (consistent with
+      # the apps-prod/*.yaml repo manifests); the kubelet's k3s containerd mirror
+      # resolves 192.168.5.1:30500 -> 192.168.64.21:30500 (the in-cluster registry the
+      # build job pushed to above), so the pull succeeds.
       REGISTRY: 192.168.5.1:30500
       NAMESPACE: apps-prod
       ROLLOUT_TIMEOUT: ${{ inputs.rollout-timeout }}


### PR DESCRIPTION
## Problem

Every `master` merge in repos using `rfcx-local-cd.yaml` (rfcx-api etc.) deploys, but the
new immutable `rfcx-local-prod-<sha>` image is **unpullable** → `ImagePullBackOff` on every
rollout pod. Old pods keep serving (no outage), but the new code never actually deploys.

## Root cause — a two-registry split

`192.168.5.1:30500` resolves to **two different registries** depending on who asks:

| | Registry A (in-cluster) | Registry B (orphan host-gw) |
|---|---|---|
| address | `192.168.64.21:30500` → `data/registry` pod | a separate registry on the colima host gateway |
| catalog | full apps-prod set | tiny (`backend, core-api, …, noncore-api`) |

- The **build** job's `docker buildx` talks **directly** to `192.168.5.1:30500` → on the build
  node that's **Registry B**. The `rfcx-local-prod-<sha>` tag lands in B. ✅
- The **kubelet** pulls `192.168.5.1:30500/...`, but k3s `registries.yaml` on every node mirrors
  `192.168.5.1:30500 → http://192.168.64.21:30500` = **Registry A**, which doesn't have the tag → 404.

buildx/dockerd does **not** honor the containerd mirror, so build-push and kubelet-pull land on
different physical registries. (Confirmed: catalogs differ; `noncore-api:rfcx-local-prod-70b8667`
exists only in B; a hand-built image pushed to `64.21` pulled cleanly.)

This is a leftover from the host-gateway → in-cluster registry migration (`registries.yaml.bak-hostgw-*`):
the kubelet/mirror side was migrated, the CI `REGISTRY` value was not.

## Fix

Point the **build** job (and its buildkit insecure-registry config) at the in-cluster registry's
direct node address `192.168.64.21:30500`. The **deploy** job keeps `set image` referencing
`192.168.5.1:30500` so deployment image refs stay consistent with `apps-prod/*.yaml`; the kubelet
mirror resolves that to `64.21`, where the image now actually lives.

## Validation

Reproduced a buildx push (CI path, inline insecure config) to `192.168.64.21:30500` from the build
node → image appears in the in-cluster registry catalog. The previously hand-built `noncore-api`
image pushed to the same `64.21` address pulled cleanly into apps-prod.

Centralized fix — covers all repos calling this reusable workflow.
