### PR TITLE
fix(rfcx-local-cd): repoint build-push from retired .64.21 registry to HA tier (.2.200)

### DIFF
--- a/.github/workflows/rfcx-local-cd.yaml
+++ b/.github/workflows/rfcx-local-cd.yaml
@@ -75,14 +75,23 @@ jobs:
         target: ${{ fromJson(inputs.targets) }}
       fail-fast: false
     env:
-      # Push to the in-cluster registry by its DIRECT node address (control-plane
-      # NodePort), NOT the 192.168.5.1:30500 host-gateway alias. buildx/dockerd does
-      # NOT honor the k3s containerd registry mirror (192.168.5.1:30500 ->
-      # 192.168.64.21:30500), so on the build node 192.168.5.1:30500 hits a SEPARATE
-      # orphan host-gateway registry. The kubelet, which DOES follow the mirror, then
-      # pulls from 192.168.64.21:30500 and 404s (ImagePullBackOff). Pushing here makes
-      # build-push and kubelet-pull land on the same physical registry.
-      REGISTRY: 192.168.64.21:30500
+      # Push to the in-cluster HA registry by a DIRECT, REACHABLE node NodePort,
+      # NOT the 192.168.5.1:30500 host-gateway alias. buildx (docker-container
+      # driver) does NOT honor the k3s containerd registry mirror that maps
+      # 192.168.5.1:30500 -> the registry nodes, so the build job must target a
+      # real registry address itself.
+      #
+      # 2026-06-29: repointed from the RETIRED control-plane node 192.168.64.21
+      # (old single registry on rfcx-platform-a, decommissioned 2026-06-26 -> the
+      # build-push timed out: `dial 192.168.64.21:30500 i/o timeout`) to the HA
+      # registry tier (rfcx-registry-1/2/3 on 192.168.2.199/200/201, NodePort
+      # 30500, 3 stateless replicas over one shared distributed-MinIO backend; see
+      # data-stores/registry-ha/). NodePort 30500 on ANY node load-balances to a
+      # healthy replica, and all replicas share state, so build-push here is
+      # immediately visible to the kubelet pull (which resolves 192.168.5.1:30500
+      # to these same .2.x nodes via registries.yaml). .2.200 chosen to match the
+      # already-applied workaround in scripts/build-analysis-workers.sh.
+      REGISTRY: 192.168.2.200:30500
     outputs:
       unique-tag: ${{ steps.meta.outputs.unique-tag }}
     steps:
@@ -93,7 +102,7 @@ jobs:
         with:
           driver: docker-container
           buildkitd-config-inline: |
-            [registry."192.168.64.21:30500"]
+            [registry."192.168.2.200:30500"]
               http = true
               insecure = true
 
@@ -130,8 +139,10 @@ jobs:
     env:
       # set image references the 192.168.5.1:30500 host-gateway alias (consistent with
       # the apps-prod/*.yaml repo manifests); the kubelet's k3s containerd mirror
-      # resolves 192.168.5.1:30500 -> 192.168.64.21:30500 (the in-cluster registry the
-      # build job pushed to above), so the pull succeeds.
+      # (bootstrap/k3s-agent-configs/registries.yaml) resolves 192.168.5.1:30500 ->
+      # the HA registry nodes 192.168.2.199/200/201:30500 (where the build job pushed
+      # above), so the pull succeeds. Image REFERENCES intentionally stay on the
+      # .5.1 alias; only the build-push target moved to a reachable .2.x node.
       REGISTRY: 192.168.5.1:30500
       NAMESPACE: apps-prod
       ROLLOUT_TIMEOUT: ${{ inputs.rollout-timeout }}


### PR DESCRIPTION
## Problem
The rfcx-local app CD (`rfcx-local-cd.yaml`) **build-push** step targets `REGISTRY=192.168.64.21:30500` — the registry NodePort on the **retired** `rfcx-platform-a` control-plane node (decommissioned 2026-06-26). Every push now fails:
```
error: failed to do request: Head "https://192.168.64.21:30500/v2/.../blobs/...": dial tcp 192.168.64.21:30500: i/o timeout
```
This blocks **all** rfcx-api / app deploys (e.g. rfcx-api run `28355198693` for #662; also #661 earlier).

## Root cause
The registry was rebuilt as an HA tier (`data-stores/registry-ha/`): 3 stateless `docker/distribution` replicas (`rfcx-registry-1/2/3` on `192.168.2.199/200/201`) over **one shared distributed-MinIO backend**, NodePort 30500. The CD workflow was never updated off the old single-node `.64.21` address. buildx (docker-container driver) doesn't honor the k3s containerd registry mirror, so the build job must target a real reachable registry address itself.

## Fix (build job only)
`REGISTRY` + `buildkitd-config-inline` → `192.168.2.200:30500` (a reachable HA node; matches the workaround already in `scripts/build-analysis-workers.sh`).
- NodePort 30500 load-balances to a healthy replica; all replicas share state → the push is immediately visible to the kubelet pull.
- The kubelet resolves the **unchanged** image references (`192.168.5.1:30500` in the deploy step + `apps-prod/*.yaml`) to these same `.2.x` nodes via the containerd mirror (`bootstrap/k3s-agent-configs/registries.yaml`). So build-push and kubelet-pull land on the same physical registry.
- Deploy-step `REGISTRY` (`192.168.5.1:30500`) intentionally unchanged — image *references* stay on the alias; only the build-push *target* moved.

## Verified live (read-only)
- `/v2/` returns **HTTP 200** on all three: `.2.199`, `.2.200`, `.2.201`.
- `.64.21:30500` and `.5.1:30500` are unreachable from the host (`.64.21` = dead node; `.5.1` = in-VM alias only).
- The **build runner** (`rfcx-local-deployment-runner` on `rfcx-build-1/2`) reaches all 3 HA nodes (HTTP 200).

## Safety
**Config-only.** Does **not** touch host networking / colima / pf / routes — the ms5 `.64.x`↔`.2.x` Internet-Sharing divergence is a separate, reboot-window-blocked item (rfcx-local OPEN-ITEMS §1) and is explicitly **not** in scope here. Fully reversible (one-line revert).

🤖 rfcx-local agent session (ms4, 2026-06-29)